### PR TITLE
A few changes to the build system make integration with other packages easier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ project (RingDecomposerLib VERSION 1.0)
 
 enable_testing()
 
+# external options -- build example
+option(BUILD_MINIMAL_EXAMPLE "Build minimal example" OFF)
+
 # external options -- build our RDKit testing tool
 option(BUILD_RDKIT_BENCHMARK "Build the Benchmark with RDKit" OFF)
 
@@ -27,7 +30,7 @@ set(RDKIT_INCLUDE_DIR "" CACHE STRING "Rdkit include dir")
 # external options -- rdkit include directories
 set(RDKIT_LIB_DIR "" CACHE STRING "Rdkit librart dir")
 
-set(SOURCE_DIR "${CMAKE_SOURCE_DIR}/src")
+set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 set(LIB_SOURCE_DIR "${SOURCE_DIR}/RingDecomposerLib")
 set(PYTHON_SOURCE_DIR "${SOURCE_DIR}/python")
 
@@ -41,14 +44,24 @@ set(SHARED_MINIMALEXAMPLE "MinimalExample")
 set(STATIC_MINIMALEXAMPLE "MinimalExample_static")
 
 set(PYTHON_TEST "${PYTHON_SOURCE_DIR}/test/test.py")
-set(TEST_DIR "${CMAKE_SOURCE_DIR}/test")
+set(TEST_DIR "${CMAKE_CURRENT_SOURCE_DIR}/test")
 
 SET(CMAKE_INSTALL_RPATH "\$ORIGIN/lib")
 
 include_directories(${LIB_SOURCE_DIR})
 add_subdirectory("${LIB_SOURCE_DIR}")
 add_subdirectory("${SOURCE_DIR}/Test")
-add_subdirectory("${SOURCE_DIR}/MinimalExample")
-add_subdirectory("${SOURCE_DIR}/RDKitBenchmark")
-add_subdirectory("${PYTHON_SOURCE_DIR}")
+
+if(BUILD_MINIMAL_EXAMPLE)
+  add_subdirectory("${SOURCE_DIR}/MinimalExample")
+endif()
+
+if(BUILD_RDKIT_BENCHMARK)
+  add_subdirectory("${SOURCE_DIR}/RDKitBenchmark")
+endif()
+
+if(BUILD_PYTHON_WRAPPER)
+  add_subdirectory("${PYTHON_SOURCE_DIR}")
+endif()
+
 add_subdirectory("${TEST_DIR}")

--- a/src/RingDecomposerLib/CMakeLists.txt
+++ b/src/RingDecomposerLib/CMakeLists.txt
@@ -28,4 +28,6 @@ build_library("${SHARED_LIBRARY}" "SHARED")
 build_library("${STATIC_LIBRARY}" "STATIC")
 
 install(FILES RingDecomposerLib.h
-        DESTINATION include)
+RDLapsp.h    RDLcycleFams.h   RDLdimacs.h   RDLgraph.h    RDLinfo.h      RDLstack.h   RDLtesting.h
+RDLbitset.h  RDLdataStruct.h  RDLforward.h  RDLhandler.h  RDLrelation.h  RDLtarjan.h  RDLutility.h
+        DESTINATION include/RingDecomposerLib)

--- a/src/RingDecomposerLib/CMakeLists.txt
+++ b/src/RingDecomposerLib/CMakeLists.txt
@@ -28,4 +28,4 @@ build_library("${SHARED_LIBRARY}" "SHARED")
 build_library("${STATIC_LIBRARY}" "STATIC")
 
 install(FILES RingDecomposerLib.h
-        DESTINATION include/RingDecomposerLib)
+        DESTINATION RingDecomposerLib)

--- a/src/RingDecomposerLib/CMakeLists.txt
+++ b/src/RingDecomposerLib/CMakeLists.txt
@@ -28,4 +28,4 @@ build_library("${SHARED_LIBRARY}" "SHARED")
 build_library("${STATIC_LIBRARY}" "STATIC")
 
 install(FILES RingDecomposerLib.h
-        DESTINATION RingDecomposerLib)
+        DESTINATION include)

--- a/src/RingDecomposerLib/CMakeLists.txt
+++ b/src/RingDecomposerLib/CMakeLists.txt
@@ -28,6 +28,4 @@ build_library("${SHARED_LIBRARY}" "SHARED")
 build_library("${STATIC_LIBRARY}" "STATIC")
 
 install(FILES RingDecomposerLib.h
-RDLapsp.h    RDLcycleFams.h   RDLdimacs.h   RDLgraph.h    RDLinfo.h      RDLstack.h   RDLtesting.h
-RDLbitset.h  RDLdataStruct.h  RDLforward.h  RDLhandler.h  RDLrelation.h  RDLtarjan.h  RDLutility.h
         DESTINATION include/RingDecomposerLib)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,8 +5,10 @@ foreach(filename ${files})
              COMMAND "${STATIC_TEST}" "validate" "${filename}" "200")
 endforeach()
 
-add_test(NAME "test_minimal_static" WORKING_DIRECTORY "${TEST_DIR}"
-         COMMAND "${STATIC_MINIMALEXAMPLE}")
+if(BUILD_MINIMAL_EXAMPLE)
+    add_test(NAME "test_minimal_static" WORKING_DIRECTORY "${TEST_DIR}"
+            COMMAND "${STATIC_MINIMALEXAMPLE}")
+endif()
 
 if (PYTHON AND BUILD_PYTHON_WRAPPER)
     foreach(filename ${files})


### PR DESCRIPTION
I made the changes in this PR in order to allow me to use the library in the RDKit via cmake's `ExternalProject()` mechanism.
I don't think this should break anything, but I haven't tested the python wrapper
